### PR TITLE
run.sh: limit node list sizes

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -60,6 +60,8 @@ filter_list() {
 }
 
 generate_list() {
+  devp2p discv4 crawl -timeout "$CRAWL_TIMEOUT" all.json
+
   # Mainnet
   filter_list mainnet all   -limit 3000
   filter_list mainnet les   -limit 200  -les-server


### PR DESCRIPTION
This adds some size limits for the node lists. These limits mostly
affect the `snap.*` lists. After the Berlin fork, many nodes now provide
snap sync serving and there is a lot of overlap between `all.*` and
`snap.*`.